### PR TITLE
Add two simple Axon modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# axon-project
+# Axon Project
+
+This repository demonstrates a simple multi-module Maven setup using the [Axon Framework](https://axoniq.io/).
+
+## Modules
+
+- **module1** – a minimal Spring Boot application that depends on Axon.
+- **module2** – another simple Spring Boot application with the same dependency.
+
+The Axon dependency is declared via the Maven coordinates:
+
+```xml
+<dependency>
+    <groupId>org.axonframework</groupId>
+    <artifactId>axon-spring-boot-starter</artifactId>
+    <version>${axon.version}</version>
+</dependency>
+```
+
+Build the project with:
+
+```bash
+mvn package
+```

--- a/module1/pom.xml
+++ b/module1/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>axon-project</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>module1</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-starter</artifactId>
+            <version>${axon.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/module1/src/main/java/com/example/module1/Module1Application.java
+++ b/module1/src/main/java/com/example/module1/Module1Application.java
@@ -1,0 +1,11 @@
+package com.example.module1;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.SpringApplication;
+
+@SpringBootApplication
+public class Module1Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Module1Application.class, args);
+    }
+}

--- a/module2/pom.xml
+++ b/module2/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>axon-project</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>module2</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-starter</artifactId>
+            <version>${axon.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/module2/src/main/java/com/example/module2/Module2Application.java
+++ b/module2/src/main/java/com/example/module2/Module2Application.java
@@ -1,0 +1,11 @@
+package com.example.module2;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.SpringApplication;
+
+@SpringBootApplication
+public class Module2Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Module2Application.class, args);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>axon-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>module1</module>
+        <module>module2</module>
+    </modules>
+
+    <properties>
+        <java.version>17</java.version>
+        <axon.version>4.9.0</axon.version>
+        <spring-boot.version>3.1.5</spring-boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>


### PR DESCRIPTION
## Summary
- add multi-module Maven project using Axon Framework
- create module1 and module2 with simple Spring Boot apps
- document modules in README

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6882a439f5808321a692be4b54e52b16